### PR TITLE
Add GitHub Actions bot to Renovate's `gitIgnoredAuthors`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,8 @@
   ],
   "baseBranches": [
     "main"
+  ],
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com"
   ]
 }


### PR DESCRIPTION
To let renovate rebase the reviews when needed, as we sometimes need to update the ringtone dependencies file on top of a dependency bump.

https://docs.renovatebot.com/configuration-options/#gitignoredauthors